### PR TITLE
Add --name to init command

### DIFF
--- a/themes/stellar/layout/index.ejs
+++ b/themes/stellar/layout/index.ejs
@@ -34,7 +34,7 @@
   <h2>Fast Example</h2>
   
   <div class="block" style="margin-right: 5px;">
-    <figure class="highlight plain"><table><tbody><tr><td class="code"><pre><span class="line"># create a new project</span><br><span class="line">$ stellar init</span><br></pre></td></tr></tbody></table></figure>
+    <figure class="highlight plain"><table><tbody><tr><td class="code"><pre><span class="line"># create a new project</span><br><span class="line">$ stellar init --name=<var>projectname</var></span><br></pre></td></tr></tbody></table></figure>
   </div>
 
   <div class="block" style="margin-right: 5px; margin-left: 5px">


### PR DESCRIPTION
The init command seems to be missing a --name argument, so I've added that here - this argument is also missing on https://pt.stellar-framework.com/