### PR TITLE
Fix client library URL

### DIFF
--- a/src/guide/http.md
+++ b/src/guide/http.md
@@ -135,7 +135,7 @@ Although the Stellar client-side JavaScript library is mostly for WebSockets, it
   <!-- (...) -->
 
   <!-- import Stellar client library  -->
-  <script src="//server.example.com/client-lib">
+  <script src="//server.example.com/stellar-client">
 </head>
 ```
 


### PR DESCRIPTION
I believe this is the correct URL for the client library.

Oddly, this code snippet doesn't seem to exist in the Portuguese documentation - it must have been added after the translation.